### PR TITLE
feat: add styles to popup, fix service worker startup

### DIFF
--- a/source/Background/service-worker.ts
+++ b/source/Background/service-worker.ts
@@ -19,11 +19,23 @@ const settingsCache: State = {
 
 async function initSettingsCache() {
   const data = await browser.storage.sync.get(null);
-  Object.assign(settingsCache, {
-    cookieName: data.cookieName,
-    sourceUrl: new URL(data.sourceUrl),
-    targetUrls: data.targetUrls.map((s: string) => new URL(s)),
-  });
+  if (data.cookieName) {
+    Object.assign(settingsCache, {
+      cookieName: data.cookieName,
+    });
+  }
+
+  if (data.sourceUrl) {
+    Object.assign(settingsCache, {
+      sourceUrl: new URL(data.sourceUrl),
+    });
+  }
+
+  if (data.targetUrls) {
+    Object.assign(settingsCache, {
+      targetUrls: data.targetUrls.map((s: string) => new URL(s)),
+    });
+  }
 }
 
 async function fetchSourceCookie() {
@@ -95,6 +107,7 @@ async function onCookieChanged(changeInfo: Cookies.OnChangedChangeInfoType) {
   
   browser.runtime.onMessage.addListener(async (
     request: Record<string, string>,
+    // @ts-expect-error
     sender: Runtime.MessageSender,
   ) => {
     if (request.command === "sync-now") {
@@ -106,9 +119,6 @@ async function onCookieChanged(changeInfo: Cookies.OnChangedChangeInfoType) {
     }
     return false;
   });
-
-  const [urls, cookie] = await Promise.all([getTargetUrls(), fetchSourceCookie()]);
-  setTargetCookies(urls, cookie);
 })();
 
 export {};

--- a/source/Popup/Popup.tsx
+++ b/source/Popup/Popup.tsx
@@ -1,25 +1,60 @@
-import { browser } from "webextension-polyfill-ts";
+import { browser } from 'webextension-polyfill-ts';
 import * as React from 'react';
 
-import Value from './Value';
-
 import './styles.scss';
+import FailedIcon from './icons/FailedIcon';
+import SuccessIcon from './icons/SuccessIcon';
 
 const Popup: React.FC = () => {
-  const [lastResult, setLastResult] = React.useState();
+  const [result, setResult] = React.useState<any[] | string | null>(null);
+  const [isLoading, setIsLoading] = React.useState(false);
+  const [isError, setIsError] = React.useState(false);
 
   const syncNow = React.useCallback(async () => {
-    const resp = await browser.runtime.sendMessage({ command: "sync-now" });
-    setLastResult(resp);
+    setIsLoading(true);
+    setIsError(false);
+    setResult(null);
+
+    try {
+      const resp = await browser.runtime.sendMessage({ command: 'sync-now' });
+      setResult(resp);
+    } catch (err: any) {
+      setResult(err.message);
+      setIsError(true);
+      console.error(err);
+    } finally {
+      setIsLoading(false);
+    }
   }, []);
 
   return (
     <section id="popup">
-      <h2>Cookie Sync</h2>
-      <button type="button" onClick={() => syncNow()}>
-        Sync Cookies Now
-      </button>
-      {lastResult ? <Value label="Sync'd">{lastResult}</Value> : null}
+      <h1>Cookie Sync</h1>
+      <div style={{ textAlign: 'center' }}>
+        <button type="button" className="sync-button" onClick={syncNow} disabled={isLoading}>
+          Sync Cookies Now
+        </button>
+      </div>
+
+      {isError ? (
+        <div className="error-alert">
+          <FailedIcon width={20} height={20} />
+          <div>{result}</div>
+        </div>
+      ) : null}
+
+      {/* TODO: Assuming result is an array */}
+      {/* TODO: Could pull out into component */}
+      <div className="result">
+        {!isError && Array.isArray(result)
+          ? result.map((res, index) => (
+              <div key={index} className="success-row">
+                <SuccessIcon width={20} height={20} />
+                <div>{res.value.domain}</div>
+              </div>
+            ))
+          : null}
+      </div>
     </section>
   );
 };

--- a/source/Popup/icons/FailedIcon.tsx
+++ b/source/Popup/icons/FailedIcon.tsx
@@ -1,0 +1,25 @@
+import * as React from 'react';
+import { forwardRef } from 'react';
+
+export default forwardRef<SVGSVGElement, React.SVGAttributes<SVGSVGElement>>(function FailedIcon(
+  props,
+  ref
+) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={1.5}
+      stroke="currentColor"
+      {...props}
+      ref={ref}
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M9.75 9.75l4.5 4.5m0-4.5l-4.5 4.5M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+      />
+    </svg>
+  );
+});

--- a/source/Popup/icons/SuccessIcon.tsx
+++ b/source/Popup/icons/SuccessIcon.tsx
@@ -1,0 +1,25 @@
+import * as React from 'react';
+import { forwardRef } from 'react';
+
+export default forwardRef<SVGSVGElement, React.SVGAttributes<SVGSVGElement>>(function FailedIcon(
+  props,
+  ref
+) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={1.5}
+      stroke="currentColor"
+      {...props}
+      ref={ref}
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M14.563 9.75a12.014 12.014 0 00-3.427 5.136L9 12.75M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+      />
+    </svg>
+  );
+});

--- a/source/Popup/styles.scss
+++ b/source/Popup/styles.scss
@@ -3,16 +3,17 @@
 @import "../styles/variables";
 
 body {
-  color: $black;
-  background-color: $greyWhite;
+  color: $gray500;
+  background-color: $surface100;
 }
 
 #popup {
   min-width: 350px;
-  padding: 30px 20px;
+  padding: 20px 20px;
 
-  h2 {
-    font-size: 25px;
+  h1 {
+    font-size: 1.625rem;
+    font-weight: 600;
     text-align: center;
   }
 
@@ -22,4 +23,44 @@ body {
   dd {
     margin-left: 1em;
   }
+}
+
+.sync-button {
+  border-radius: 4px;
+  display: inline-block;
+  border-radius: 4px;
+  text-transform: none;
+  font-weight: 600;
+  color: #FFFFFF;
+  background-color: #7669D3;
+  border: 1px solid #7669D3;
+  height: 34px;
+  font-size: 0.875rem;
+  line-height: 1rem;
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 8px;
+  padding-bottom: 8px;
+  box-shadow: 0 1px 4px rgb(10 8 12 / 20%);
+  cursor: pointer;
+  margin-bottom: 16px;
+}
+
+.result {
+  display: flex;
+  gap: 8px;
+  flex-direction: column;
+}
+
+.error-alert {
+  color: $red300;
+  display: flex;
+  gap: 8px;
+}
+
+.success-row {
+  color: $green400;
+  display: flex;
+  gap: 8px;
+  align-items: center;
 }

--- a/source/manifest.json
+++ b/source/manifest.json
@@ -2,7 +2,7 @@
   "__chrome|opera|edge__manifest_version": 3,
   "__firefox__manifest_version": 2,
 
-  "name": "Sample WebExtension",
+  "name": "Sentry Cookie Sync",
   "version": "0.0.0",
 
   "icons": {
@@ -54,7 +54,7 @@
       "48": "assets/icons/favicon-48.png",
       "128": "assets/icons/favicon-128.png"
     },
-    "default_title": "tiny title",
+    "default_title": "Sentry Cookie Sync",
     "browser_style": false
   },
   "__chrome|opera__action": {
@@ -65,7 +65,7 @@
       "48": "assets/icons/favicon-48.png",
       "128": "assets/icons/favicon-128.png"
     },
-    "default_title": "tiny title"
+    "default_title": "Sentry Cookie Sync"
   },
 
   "__chrome|opera__options_page": "options.html",

--- a/source/styles/_variables.scss
+++ b/source/styles/_variables.scss
@@ -3,6 +3,21 @@ $black: #0d0d0d;
 $greyWhite: #f3f3f3;
 $skyBlue: #8892b0;
 
+// DarkTheme Colors from theme.tsx from sentry
+$surface100: #1A141F;
+$red300: #F55459;
+
+$gray500: #EBE6EF;
+$gray400: #D6D0DC;
+$gray300: #998DA5;
+$gray200: #43384C;
+$gray100: #342B3B;
+
+$green400: #26B593;
+$green300: #2AC8A3;
+$green200: rgba(42, 200, 163, 0.4);
+$green100: rgba(42, 200, 163, 0.1);
+
 // fonts
 $nunito: "Nunito", sans-serif;
 


### PR DESCRIPTION
Adds styles for success and error, stops calling a few functions at launch in the service worker that was causing the service worker to crash for me.

success
![Screen Shot 2022-08-23 at 5 45 56 PM](https://user-images.githubusercontent.com/1400464/186291335-69935454-02ab-47df-b6ee-6b06f00b0a07.png)

error
![Screen Shot 2022-08-23 at 5 46 25 PM](https://user-images.githubusercontent.com/1400464/186291378-c029c960-e22c-430d-8900-dea91a28bd43.png)

